### PR TITLE
Add C development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore compiled objects
+*.o
+*.out
+a.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:bookworm
+
+# Install build essentials for C development
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /work
+
+# Default to bash shell
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # os
-os
+
+Development environment for C language programs.
+
+## Using Docker
+
+A Dockerfile is provided with the necessary tools to compile C code using GCC. Build the image:
+
+```sh
+docker build -t c-env .
+```
+
+Run the container, mounting your current project:
+
+```sh
+docker run --rm -it -v "$PWD":/work c-env
+```


### PR DESCRIPTION
## Summary
- Provide Dockerfile with GCC-based build essentials
- Document how to build and run the container
- Ignore common C build artifacts

## Testing
- `gcc sample.c -o sample && ./sample`


------
https://chatgpt.com/codex/tasks/task_e_68a18bfad5f08331b7f0a7787c36d792